### PR TITLE
mag tables additions

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -102,6 +102,7 @@
 	. += new/datum/stack_recipe/furniture/crate(src)
 	. += new/datum/stack_recipe/grip(src)
 	. += new/datum/stack_recipe/missile_casing(src)
+	. += new/datum/stack_recipe/furniture/mag_tables(src)
 
 /material/stone/generate_recipes(var/reinforce_material)
 	. = ..()

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -154,6 +154,13 @@ ARMCHAIR(yellow)
 	result_type = /obj/structure/table
 	time = 10
 
+/datum/stack_recipe/furniture/mag_tables
+	title = "magnetic table"
+	result_type = /obj/structure/table/mag
+	req_amount = 20
+	time = 50
+
+
 /datum/stack_recipe/furniture/rack
 	title = "rack"
 	result_type = /obj/structure/table/rack

--- a/code/modules/tables/mag_tables.dm
+++ b/code/modules/tables/mag_tables.dm
@@ -4,7 +4,7 @@
 	icon_state = "magnetic_table_disabled"
 	var/icon_state_open = "magnetic_table_disabled"
 	var/icon_state_closed = "magnetic_table_enabled"
-	req_access = list(access_merchant)
+	req_access = list(access_cargo)
 	can_plate = 0
 	can_reinforce = 0
 	flipped = -1


### PR DESCRIPTION
* Added crafting recipe for mag tables: 20 plasteel, experienced construction skill level required
* Mag tables spawns with cargo access requirement by default now

